### PR TITLE
Fix: Prevent Enter key submission during Japanese IME composition

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1061,6 +1061,7 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
   const [slashPosition, setSlashPosition] = useState(-1);
   const [visibleMessageCount, setVisibleMessageCount] = useState(100);
   const [claudeStatus, setClaudeStatus] = useState(null);
+  const [isComposing, setIsComposing] = useState(false);
 
 
   // Memoized diff calculation to prevent recalculating on every render
@@ -1998,6 +1999,11 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
     
     // Handle Enter key: Ctrl+Enter (Cmd+Enter on Mac) sends, Shift+Enter creates new line
     if (e.key === 'Enter') {
+      // Don't submit if IME is composing (for Japanese, Chinese, Korean input)
+      if (e.isComposing || isComposing) {
+        return;
+      }
+      
       if ((e.ctrlKey || e.metaKey) && !e.shiftKey) {
         // Ctrl+Enter or Cmd+Enter: Send message
         e.preventDefault();
@@ -2327,6 +2333,8 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
               onPaste={handlePaste}
               onFocus={() => setIsInputFocused(true)}
               onBlur={() => setIsInputFocused(false)}
+              onCompositionStart={() => setIsComposing(true)}
+              onCompositionEnd={() => setIsComposing(false)}
               onInput={(e) => {
                 // Immediate resize on input for better UX
                 e.target.style.height = 'auto';


### PR DESCRIPTION
## Summary
- Fixed an issue where pressing Enter during Japanese text input would submit the message instead of confirming the IME conversion
- Added proper IME composition handling to respect the text input process for CJK languages

## Changes
- Added `isComposing` state to track when IME is active
- Modified `handleKeyDown` to check both `e.isComposing` and the state variable
- Added `onCompositionStart` and `onCompositionEnd` event handlers to the textarea

## Test plan
- [ ] Type Japanese text using IME in the input field
- [ ] Press Enter during character conversion - it should confirm the conversion, not submit
- [ ] After conversion is complete, Enter should submit the message normally
- [ ] Ctrl/Cmd+Enter should still work to force submission
- [ ] Regular English input should work as before

🤖 Generated with [Claude Code](https://claude.ai/code)